### PR TITLE
feat: linkeding integration

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -4,6 +4,7 @@ NEXT_PUBLIC_URL=http://localhost:3000
 LINKEDIN_API_ME=https://api.linkedin.com/v2/me
 LINKEDIN_API_ACCESS_TOKEN=https://www.linkedin.com/oauth/v2/accessToken
 LINKEDIN_API_RETRIEVE_ME_PICTURE=https://api.linkedin.com/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))
+LINKEDIN_API_RETRIEVE_ME_EMAIL=https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))
 NEXT_PUBLIC_LINKEDIN_CLIENT_SCOPE=r_liteprofile r_emailaddress
 NEXT_PUBLIC_LINKEDIN_CLIENT_ID=
 LINKEDIN_CLIENT_SECRET=

--- a/src/pages/api/linkedin/callback/index.ts
+++ b/src/pages/api/linkedin/callback/index.ts
@@ -1,0 +1,72 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import axios from 'axios'
+import {
+  LinkedinSuccessAccessTokenProps,
+  LinkedinRetrieveMePictureProps,
+  LinkedinMeProps,
+  LinkedinMeEmailProps,
+} from '~/types/data/LinkedIn'
+
+export default async function handler(request: NextApiRequest, response: NextApiResponse) {
+  if (request.method !== 'POST') {
+    response.status(500)
+
+    return
+  }
+
+  const { code } = request.body
+
+  const body = new URLSearchParams({
+    code,
+    grant_type: 'authorization_code',
+    redirect_uri: `${process.env.NEXT_PUBLIC_URL}/linkedin`,
+    client_id: process.env.NEXT_PUBLIC_LINKEDIN_CLIENT_ID,
+    client_secret: process.env.LINKEDIN_CLIENT_SECRET,
+  } as any)
+
+  try {
+    const responseAuthorizationToken = await axios.post<LinkedinSuccessAccessTokenProps>(
+      process.env.LINKEDIN_API_ACCESS_TOKEN as string,
+      body,
+      {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      }
+    )
+
+    const headers = {
+      headers: { Authorization: `Bearer ${responseAuthorizationToken.data.access_token}` },
+    }
+
+    const responseAccessToken = await axios.get<LinkedinMeProps>(process.env.LINKEDIN_API_ME as string, headers)
+
+    const responseRetrieveMePicture = await axios.get<LinkedinRetrieveMePictureProps>(
+      process.env.LINKEDIN_API_RETRIEVE_ME_PICTURE as string,
+      headers
+    )
+
+    const responseRetrieveMeEmail = await axios.get<LinkedinMeEmailProps>(
+      process.env.LINKEDIN_API_RETRIEVE_ME_EMAIL as string,
+      headers
+    )
+
+    const firstName = responseAccessToken.data.localizedFirstName
+    const lastName = responseAccessToken.data.localizedLastName
+    const fullName = `${firstName} ${lastName}`
+    const picture = responseRetrieveMePicture.data.profilePicture['displayImage~'].elements[0].identifiers[0].identifier
+    const email = responseRetrieveMeEmail.data.elements[0]['handle~'].emailAddress
+
+    const data = {
+      firstName,
+      lastName,
+      fullName,
+      picture,
+      email,
+    }
+
+    response.status(200).json({ data })
+  } catch (error) {
+    response.status(500).json({ message: error.message })
+  }
+}

--- a/src/pages/linkedin/index.tsx
+++ b/src/pages/linkedin/index.tsx
@@ -1,0 +1,15 @@
+import { FC } from 'react'
+import dynamic from 'next/dynamic'
+
+const LinkedInOAuth2PopUp = dynamic(
+  async () => {
+    const { LinkedInPopUp } = await import('react-linkedin-login-oauth2')
+
+    return LinkedInPopUp
+  },
+  { ssr: false }
+)
+
+const Component: FC = () => <LinkedInOAuth2PopUp />
+
+export default Component

--- a/src/types/data/LinkedIn.d.ts
+++ b/src/types/data/LinkedIn.d.ts
@@ -1,0 +1,51 @@
+export interface LinkedinSuccessAuthorizationTokenProps {
+  code: string
+}
+
+export interface LinkedinSuccessAccessTokenProps {
+  access_token: string
+  expires_in: string
+}
+
+export interface LinkedinDisplayImageElementsIdentifiersProps {
+  identifier: string
+  mediaType: string
+  identifierExpiresInSeconds: number
+}
+
+export interface LinkedinDisplayImageElementsProps {
+  artifact: string
+  authorizationMethod: string
+  identifiers: LinkedinDisplayImageElementsIdentifiersProps[]
+}
+
+export interface LinkedinRetrieveMePictureProps {
+  profilePicture: {
+    'displayImage~': {
+      elements: LinkedinDisplayImageElementsProps[]
+    }
+  }
+}
+
+export interface LinkedinMeProps {
+  localizedLastName: string
+  localizedFirstName: string
+}
+
+export interface LinkedinMeEmailElementsProps {
+  'handle~': {
+    emailAddress: string
+  }
+}
+
+export interface LinkedinMeEmailProps {
+  elements: LinkedinMeEmailElementsProps[]
+}
+
+export interface LinkedinUserProps {
+  firstName: string
+  lastName: string
+  fullName: string
+  picture: string
+  email: string
+}


### PR DESCRIPTION
### Alterações ou observações

- Backend com integração a APIs do LinkedIn para captura dos dados como básicos, e-mail e foto.

### Validação

- Rodar ambiente, _lint_ e testes;
- Clicar no botão do LinkedIn, seguir os passos até o _popup_ fechar e ver se a _request_ retornou os dados.

### Referências

- http://npmjs.org/package/react-linkedin-login-oauth2
- https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin?context=linkedin/consumer/context
- https://docs.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow?context=linkedin/context